### PR TITLE
Memory-leak (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Could be studied by day as individual, group and/or dojo.
 
 ### Module 5 (1h) ###
 * [Closures](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures)
-    * [Memory-leak]()
 
 > [Exercise 5](./exercises/5.module.md)
 


### PR DESCRIPTION
Memory-leak estava com link quebrado, porém conforme conversamos, memory-leak não deve ser tão abordado nesse nível de conteúdo e talvez não necessite de um link, apenas de uma breve explicação. Por isso removi a referência.